### PR TITLE
Added option to enable windows authentication for IIS Express

### DIFF
--- a/src/DryRunner.Tests/TestSiteManagerTests.cs
+++ b/src/DryRunner.Tests/TestSiteManagerTests.cs
@@ -34,6 +34,16 @@ namespace DryRunner.Tests
         }
 
         [Test]
+        public void CanDeploySiteWithEnableWindowsAuthentication()
+        {
+            var manager = new TestSiteManager("DryRunner.TestWebsite", new TestSiteOptions
+            {
+                EnableWindowsAuthentication = true
+            });
+            CheckSite(manager, "http://localhost:8888");
+        }
+
+        [Test]
         public void CanDeploySite_CustomPortAndApplicationPath()
         {
             var manager = new TestSiteManager("DryRunner.TestWebsite", new TestSiteOptions

--- a/src/DryRunner/TestSiteManager.cs
+++ b/src/DryRunner/TestSiteManager.cs
@@ -30,7 +30,7 @@ namespace DryRunner
 	        _deployer = new TestSiteDeployer(siteRoot, options.ProjectFileName ?? projectName + ".csproj", options.SolutionDir, options.ProjectDir, options.Targets);
             _server = new TestSiteServer(_deployer.TestSitePath, 
                 options.Port, options.ApplicationPath, 
-                options.ShowIisExpressWindow);
+                options.ShowIisExpressWindow, options.EnableWindowsAuthentication);
 	    }
 
 	    public void Start()

--- a/src/DryRunner/TestSiteOptions.cs
+++ b/src/DryRunner/TestSiteOptions.cs
@@ -47,6 +47,11 @@ namespace DryRunner
         /// </summary>
         public bool ShowIisExpressWindow { get; set; }
 
+        /// <summary>
+        /// Enables Windows Authentication for IIS Express.
+        /// </summary>
+        public bool EnableWindowsAuthentication { get; set; }
+
         public TestSiteOptions()
         {
             Port = 8888;

--- a/src/DryRunner/TestSiteServer.cs
+++ b/src/DryRunner/TestSiteServer.cs
@@ -11,16 +11,18 @@ namespace DryRunner
         private readonly int _port;
         private readonly string _applicationPath;
 	    private readonly bool _showIisExpressWindow;
+	    private readonly bool _enableWindowsAuthentication;
 
 	    private Process _process;
 		private ManualResetEventSlim _manualResetEvent;
 
-	    public TestSiteServer(string physicalSitePath, int port, string applicationPath, bool showIisExpressWindow)
+	    public TestSiteServer(string physicalSitePath, int port, string applicationPath, bool showIisExpressWindow, bool enableWindowsAuthentication)
 	    {
 	        _physicalSitePath = physicalSitePath;
 	        _port = port;
 	        _applicationPath = applicationPath;
 	        _showIisExpressWindow = showIisExpressWindow;
+	        _enableWindowsAuthentication = enableWindowsAuthentication;
 	    }
 
 	    public void Start()
@@ -76,9 +78,10 @@ namespace DryRunner
 	    {
 	        var applicationHostConfig = new StringBuilder(GetApplicationHostConfigTemplate());
 	        applicationHostConfig
-	            .Replace("{{PORT}}", _port.ToString())
-	            .Replace("{{PHYSICAL_PATH}}", _physicalSitePath)
-	            .Replace("{{APPLICATION_PATH}}", _applicationPath);
+	            .Replace ("{{PORT}}", _port.ToString())
+	            .Replace ("{{PHYSICAL_PATH}}", _physicalSitePath)
+	            .Replace ("{{APPLICATION_PATH}}", _applicationPath)
+	            .Replace ("{{WINDOWS_AUTHENTICATION_ENABLED}}", _enableWindowsAuthentication ? "true" : "false");
 
 	        // There must always be a default application. So if we do not deploy to "/" we uncomment our dummy default application.
 	        // This default application gets served from a new directory created inside the physical path of our site (to avoid access rights issues).

--- a/src/DryRunner/applicationHost.config
+++ b/src/DryRunner/applicationHost.config
@@ -326,7 +326,7 @@
 				<iisClientCertificateMappingAuthentication enabled="false">
 				</iisClientCertificateMappingAuthentication>
 
-				<windowsAuthentication enabled="false">
+				<windowsAuthentication enabled="{{WINDOWS_AUTHENTICATION_ENABLED}}">
 					<providers>
 						<add value="Negotiate" />
 						<add value="NTLM" />


### PR DESCRIPTION
The `applicationHost.config` doesn't allow Windows Authentication in IIS Express by default. With the new option `EnableWindowsAuthentication`, the default behavior will be overridden so that Windows Authentication will be available in IIS Express.