### PR TITLE
Changed Stop method to cleanly shutdown IIS Express.

### DIFF
--- a/src/DryRunner/TestSiteServer.cs
+++ b/src/DryRunner/TestSiteServer.cs
@@ -110,17 +110,17 @@ namespace DryRunner
         if (_process == null)
           return;
 
-        PostMessage(_process.MainWindowHandle, WM_KEYDOWN, VK_Q, 0);
+        PostMessage(new HandleRef(_process, _process.MainWindowHandle), WM_KEYDOWN, VK_Q, IntPtr.Zero);
         _process.WaitForExit(5000);
         if (!_process.HasExited)
           _process.Kill();
       }
 
       private const int WM_KEYDOWN = 0x100;
-      private const int VK_Q = 0x51;
+      private static readonly IntPtr VK_Q = new IntPtr(0x51);
 
       [return: MarshalAs(UnmanagedType.Bool)]
       [DllImport("user32.dll")]
-      static extern bool PostMessage(IntPtr hWnd, uint msg, int wParam, int lParam);
+      static extern bool PostMessage(HandleRef hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 	}
 }

--- a/src/DryRunner/TestSiteServer.cs
+++ b/src/DryRunner/TestSiteServer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
@@ -104,15 +105,22 @@ namespace DryRunner
 	            return reader.ReadToEnd();
 	    }
 
-	    public void Stop()
-	    {
-	        if (_process == null)
-	            return;
+      public void Stop()
+      {
+        if (_process == null)
+          return;
 
-	        _process.CloseMainWindow();
-	        _process.WaitForExit(5000);
-	        if (!_process.HasExited)
-	            _process.Kill();
-	    }
+        PostMessage(_process.MainWindowHandle, WM_KEYDOWN, VK_Q, 0);
+        _process.WaitForExit(5000);
+        if (!_process.HasExited)
+          _process.Kill();
+      }
+
+      private const int WM_KEYDOWN = 0x100;
+      private const int VK_Q = 0x51;
+
+      [return: MarshalAs(UnmanagedType.Bool)]
+      [DllImport("user32.dll")]
+      static extern bool PostMessage(IntPtr hWnd, uint msg, int wParam, int lParam);
 	}
 }


### PR DESCRIPTION
I ran into an issue when using DryRunner with JetBrains dotCover to get coverage analysis results for my web tests. Unfortunately dotCover seemingly discards coverage results from processes that exit with an exit code that is not 0.

To fix this issue, DryRunner can close the IIS Express process more cleanly by sending a message to the IIS Express process that tells it to shut itself down (the message in this case is the letter "q").

This pull request implements the proposed change without introducing any new dependencies, unfortunately it is necessary to use Interop to actually send the message. An alternative would be to use System.Windows.Forms.SendKeys, but this would introduce an unnecessary dependency to Windows.Forms which all things considered is the worse option compared to using a single Interop call.